### PR TITLE
SASS template syntax should be updated

### DIFF
--- a/lib/generators/nifty/layout/templates/stylesheet.sass
+++ b/lib/generators/nifty/layout/templates/stylesheet.sass
@@ -1,66 +1,66 @@
-!primary_color = #4B7399
+$primary_color: #4b7399
 
 body
-  :background-color = !primary_color
-  :font
-    :family Verdana, Helvetica, Arial
-    :size 14px
+  background-color: $primary_color
+  font:
+    family: Verdana, Helvetica, Arial
+    size: 14px
 
 a
-  :color #0000FF
+  color: blue
   img
-    :border none
+    border: none
 
 .clear
-  :clear both
-  :height 0
-  :overflow hidden
+  clear: both
+  height: 0
+  overflow: hidden
 
 #container
-  :width 75%
-  :margin 0 auto
-  :background #fff
-  :padding 20px 40px
-  :border solid 1px black
-  :margin-top 20px
+  width: 75%
+  margin: 0 auto
+  background: white
+  padding: 20px 40px
+  border: solid 1px black
+  margin-top: 20px
 
 #flash_notice,
 #flash_error,
 #flash_alert
-  :padding 5px 8px
-  :margin 10px 0
+  padding: 5px 8px
+  margin: 10px 0
 
 #flash_notice
-  :background-color #CFC
-  :border solid 1px #6C6
+  background-color: #ccffcc
+  border: solid 1px #66cc66
 
 #flash_error,
 #flash_alert
-  :background-color #FCC
-  :border solid 1px #C66
+  background-color: #ffcccc
+  border: solid 1px #cc6666
 
 .fieldWithErrors
-  :display inline
+  display: inline
 
 .error_messages
-  :width 400px
-  :border 2px solid #CF0000
-  :padding 0
-  :padding-bottom 12px
-  :margin-bottom 20px
-  :background-color #f0f0f0
-  :font
-    :size 12px
+  width: 400px
+  border: 2px solid #cf0000
+  padding: 0
+  padding-bottom: 12px
+  margin-bottom: 20px
+  background-color: #f0f0f0
+  font:
+    size: 12px
   h2
-    :text-align left
-    :padding 5px 5px 5px 15px
-    :margin 0
-    :font
-      :weight bold
-      :size 12px
-    :background-color #c00
-    :color #fff
+    text-align: left
+    padding: 5px 5px 5px 15px
+    margin: 0
+    font:
+      weight: bold
+      size: 12px
+    background-color: #cc0000
+    color: white
   p
-    :margin 8px 10px
+    margin: 8px 10px
   ul
-    :margin 0
+    margin: 0


### PR DESCRIPTION
Current standard SASS syntax is different than used in layout's SASS template.
