### PR TITLE
Support an 'all' environments group for config files

### DIFF
--- a/features/nifty_config.feature
+++ b/features/nifty_config.feature
@@ -15,3 +15,27 @@ Feature: Nifty Config Generator
     Then I should see "FOO_BAR_CONFIG" in file "config/initializers/load_foo_bar_config.rb"
     And I should see "config/foo_bar_config.yml" in file "config/initializers/load_foo_bar_config.rb"
     And I should see file "config/foo_bar_config.yml"
+
+  Scenario: Retrieve data from config
+    Given a new Rails app
+    When I run "rails g nifty:config FooBar"
+    And the following text is put into the file "config/foo_bar_config.yml"
+      """
+      all:
+        one: One
+
+      development:
+        two: Two
+        three: Three
+
+      test:
+        one: 1
+      """
+    Then the constant FOO_BAR_CONFIG should contain the following data when in the development environment:
+      | Key   | Value |
+      | one   | One   |
+      | two   | Two   |
+      | three | Three |
+    And the constant FOO_BAR_CONFIG should contain the following data when in the test environment:
+      | Key   | Value |
+      | one   | 1     |

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -42,3 +42,7 @@ end
 Then /^I should successfully run "([^\"]*)"$/ do |command|
   system("cd #{@current_directory} && #{command}").should be_true
 end
+
+When /^the following text is put into the file "([^\"]*)"$/ do |file_name, content|
+  File.open(File.join(@current_directory, file_name), 'w') { |f| f.write(content) }
+end

--- a/features/step_definitions/nifty_config_steps.rb
+++ b/features/step_definitions/nifty_config_steps.rb
@@ -1,0 +1,11 @@
+Then /^the constant (.*) should contain the following data when in the (.*) environment:$/ do |constant_name, environment, table|
+  config_name = constant_name.split('_CONFIG')[0]
+  load_nifty_config(config_name, environment)
+
+  config = []
+  Object.const_get(constant_name).stringify_keys.each_pair do |key, value|
+    config.push({'Key' => key, 'Value' => value.to_s})
+  end
+
+  table.hashes.each { |row| config.include?(row).should be_true }
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,19 @@
 require 'cucumber'
 require 'rspec'
+require 'mocha'
+require 'active_support/core_ext'
+
+World(Mocha::Standalone)
 
 Before do
   FileUtils.rm_rf "tmp/rails_app"
+  mocha_setup
+end
+
+After do
+  begin
+    mocha_verify
+  ensure
+    mocha_teardown
+  end
 end

--- a/features/support/nifty_config_helpers.rb
+++ b/features/support/nifty_config_helpers.rb
@@ -1,0 +1,10 @@
+module NiftyConfigHelpers
+  def load_nifty_config(config_name, environment)
+    Object.const_set(:Rails, mock) unless defined?(Rails)
+    Rails.expects(:env).returns(environment)
+    Rails.expects(:root).returns(Pathname.new(@current_directory))
+    load File.expand_path("config/initializers/load_#{config_name.underscore}_config.rb", @current_directory)
+  end
+end
+
+World(NiftyConfigHelpers)

--- a/lib/generators/nifty/config/templates/config.yml
+++ b/lib/generators/nifty/config/templates/config.yml
@@ -1,3 +1,6 @@
+all:
+  title: My App
+
 development:
   domain: localhost:3000
 

--- a/lib/generators/nifty/config/templates/load_config.rb
+++ b/lib/generators/nifty/config/templates/load_config.rb
@@ -1,2 +1,4 @@
-raw_config = File.read("#{Rails.root}/config/<%= file_name %>_config.yml")
-<%= constant_name %>_CONFIG = YAML.load(raw_config)[Rails.env].symbolize_keys
+config = YAML.load File.read(Rails.root + 'config/<%= file_name %>_config.yml')
+<%= constant_name %>_CONFIG = config['all'] || {}
+<%= constant_name %>_CONFIG.merge! config[Rails.env] || {}
+<%= constant_name %>_CONFIG.symbolize_keys!

--- a/rails_generators/nifty_config/templates/config.yml
+++ b/rails_generators/nifty_config/templates/config.yml
@@ -1,3 +1,6 @@
+all:
+  title: My App
+
 development:
   domain: localhost:3000
 

--- a/rails_generators/nifty_config/templates/load_config.rb
+++ b/rails_generators/nifty_config/templates/load_config.rb
@@ -1,2 +1,4 @@
-raw_config = File.read(RAILS_ROOT + "/config/<%= file_name %>_config.yml")
-<%= constant_name %>_CONFIG = YAML.load(raw_config)[RAILS_ENV].symbolize_keys
+config = YAML.load File.read(RAILS_ROOT + "/config/<%= file_name %>_config.yml")
+<%= constant_name %>_CONFIG = config['all'] || {}
+<%= constant_name %>_CONFIG.merge! config[RAILS_ENV] || {}
+<%= constant_name %>_CONFIG.symbolize_keys!


### PR DESCRIPTION
A lot of the time you want some of your config values to be the same across all environments.

Config values put under an 'all' group can be echoed across all environments.

When a config value is defined in both 'all' and the specific environment, the more specific one takes precedence.

Example:

```
all:
  title: My App
  description: Awesome new timetracking application.

development:
  title: My App [DEVELOPMENT]
  domain: http://myapp.local:3000

test:
  domain: http://test.local:3000

production:
  domain: http://timer.com
```

Would give you a config hash like this, when in the development environment:

```
{ 
  :title => 'My App [DEVELOPMENT]', 
  :description => 'Awesome new timetracking application', 
  :domain => 'http://myapp.local:3000'
}
```
