### PR TITLE
HAML templates need an equal sign

### DIFF
--- a/lib/generators/nifty/authentication/templates/views/haml/_form.html.haml
+++ b/lib/generators/nifty/authentication/templates/views/haml/_form.html.haml
@@ -1,4 +1,4 @@
-- form_for @<%= user_singular_name %> do |f|
+= form_for @<%= user_singular_name %> do |f|
   = f.error_messages
   %p
     = f.label :username

--- a/lib/generators/nifty/authentication/templates/views/haml/login.html.haml
+++ b/lib/generators/nifty/authentication/templates/views/haml/login.html.haml
@@ -3,7 +3,7 @@
 %p== Don't have an account? #{link_to "Sign up!", signup_path}
 
 <%- if options[:authlogic] -%>
-- form_for @<%= session_singular_name %> do |f|
+= form_for @<%= session_singular_name %> do |f|
   = f.error_messages
   %p
     = f.label :username

--- a/lib/generators/nifty/scaffold/templates/views/haml/_form.html.haml
+++ b/lib/generators/nifty/scaffold/templates/views/haml/_form.html.haml
@@ -1,4 +1,4 @@
-- form_for @<%= singular_name %> do |f|
+= form_for @<%= singular_name %> do |f|
   = f.error_messages
   <%- for attribute in model_attributes -%>
   %p


### PR DESCRIPTION
A small update your HAML templates to make them Rails 3 friendly. Adds the equal sign to the form_for tags. It's my first pull request so you might want to look it over.
