### PR TITLE
i18n for error_messages_for

### DIFF
--- a/lib/generators/nifty/layout/templates/error_messages_helper.rb
+++ b/lib/generators/nifty/layout/templates/error_messages_helper.rb
@@ -2,8 +2,8 @@ module ErrorMessagesHelper
   # Render error messages for the given objects. The :message and :header_message options are allowed.
   def error_messages_for(*objects)
     options = objects.extract_options!
-    options[:header_message] ||= "Invalid Fields"
-    options[:message] ||= "Correct the following errors and try again."
+    options[:header_message] ||= I18n.t(:"activerecord.errors.header", :default => "Invalid Fields")
+    options[:message] ||= I18n.t(:"activerecord.errors.message", :default => "Correct the following errors and try again.")
     messages = objects.compact.map { |o| o.errors.full_messages }.flatten
     unless messages.empty?
       content_tag(:div, :class => "error_messages") do


### PR DESCRIPTION
I added i18n for options[:header_message] and options[:message]. Left the strings you had as the default fallback but it's nice to have the i18n by default.
