### PR TITLE
- style block helpers are deprecated in new haml version

### DIFF
--- a/rails_generators/nifty_authentication/templates/views/haml/login.html.haml
+++ b/rails_generators/nifty_authentication/templates/views/haml/login.html.haml
@@ -3,7 +3,7 @@
 %p== Don't have an account? #{link_to "Sign up!", signup_path}
 
 <%- if options[:authlogic] -%>
-- form_for @<%= session_singular_name %> do |f|
+= form_for @<%= session_singular_name %> do |f|
   = f.error_messages
   %p
     = f.label :username


### PR DESCRIPTION
DEPRECATION WARNING: - style block helpers are deprecated. Please use =. (app/views/sessions/new.html.haml:5)
