### PR TITLE
Use html_safe for error_messages_for helper. Let's you use HTML in your translations.

### DIFF
--- a/lib/generators/nifty/layout/templates/error_messages_helper.rb
+++ b/lib/generators/nifty/layout/templates/error_messages_helper.rb
@@ -7,8 +7,8 @@ module ErrorMessagesHelper
     messages = objects.compact.map { |o| o.errors.full_messages }.flatten
     unless messages.empty?
       content_tag(:div, :class => "error_messages") do
-        list_items = messages.map { |msg| content_tag(:li, msg) }
-        content_tag(:h2, options[:header_message]) + content_tag(:p, options[:message]) + content_tag(:ul, list_items.join.html_safe)
+        list_items = messages.map { |msg| content_tag(:li, msg.html_safe) }
+        content_tag(:h2, options[:header_message].html_safe) + content_tag(:p, options[:message].html_safe) + content_tag(:ul, list_items.join.html_safe)
       end
     end
   end


### PR DESCRIPTION
Use html_safe translated messages. This will let you use this
      errors:
        format: "<strong>%{attribute}</strong> %{message}"

 and renders it properly
