### PR TITLE
Adds background-color to html selector in layout generator

### DIFF
--- a/lib/generators/nifty/layout/templates/stylesheet.css
+++ b/lib/generators/nifty/layout/templates/stylesheet.css
@@ -1,3 +1,7 @@
+html {
+	background-color: #4B7399;
+}
+
 body {
   background-color: #4B7399;
   font-family: Verdana, Helvetica, Arial;


### PR DESCRIPTION
Without adding this, you'll run into some visual issues with the layout like below:

http://i.imgur.com/1MVt9.png

Adding background-color to the html tag fixes this issue.
