### PR TITLE
Nifty:layout application.html.haml fixed

### DIFF
--- a/lib/generators/nifty/layout/templates/layout.html.haml
+++ b/lib/generators/nifty/layout/templates/layout.html.haml
@@ -3,7 +3,7 @@
 
   %head
     %title
-      = yield(:title).presence || "Untitled"
+      = content_for?(:title) ? yield(:title) : "Untitled"
     %meta{"http-equiv"=>"Content-Type", :content=>"text/html; charset=utf-8"}/
     = stylesheet_link_tag "<%= file_name %>"
     = javascript_include_tag :defaults


### PR DESCRIPTION
fixed `yield(:title)` behavior in `nifty:layout`. Now checking this with `presence` method.
