### PR TITLE
Very minor change in title() method.

### DIFF
--- a/rails_generators/nifty_layout/templates/helper.rb
+++ b/rails_generators/nifty_layout/templates/helper.rb
@@ -4,8 +4,8 @@
 #   helper :layout
 module LayoutHelper
   def title(page_title, show_title = true)
-    @content_for_title = page_title.to_s
     @show_title = show_title
+    @content_for_title = page_title.to_s
   end
 
   def show_title?


### PR DESCRIPTION
Swapped order of operations inside title(), fixes strange 'true' being printed to the screen in Rails 3.0.9. I wish I could say why this works, but it was just an instinct to try it while debugging.
