### PR TITLE
Replace f.error_messages in nifty auth view templates

### DIFF
--- a/rails_generators/nifty_authentication/templates/views/erb/login.html.erb
+++ b/rails_generators/nifty_authentication/templates/views/erb/login.html.erb
@@ -4,7 +4,17 @@
 
 <%- if options[:authlogic] -%>
 <%% form_for @<%= session_singular_name %> do |f| %>
-  <%%= f.error_messages %>
+  <%% if @<%= session_singular_name %>.errors.any? %>
+    <div id="error_explanation">
+      <h2><%%= pluralize(@<%= session_singular_name %>.errors.count, "error") %> prohibited this <%= session_singular_name %> from being saved:</h2>
+
+      <ul>
+      <%% @<%= session_singular_name %>.errors.full_messages.each do |msg| %>
+        <li><%%= msg %></li>
+      <%% end %>
+      </ul>
+    </div>
+  <%% end %>
   <p>
     <%%= f.label :username %><br />
     <%%= f.text_field :username %>

--- a/rails_generators/nifty_authentication/templates/views/erb/signup.html.erb
+++ b/rails_generators/nifty_authentication/templates/views/erb/signup.html.erb
@@ -3,7 +3,17 @@
 <p>Already have an account? <%%= link_to "Log in", login_path %>.</p>
 
 <%% form_for @<%= user_singular_name %> do |f| %>
-  <%%= f.error_messages %>
+  <%% if @<%= user_singular_name %>.errors.any? %>
+    <div id="error_explanation">
+      <h2><%%= pluralize(@<%= user_singular_name %>.errors.count, "error") %> prohibited this <%= user_singular_name %> from being saved:</h2>
+
+      <ul>
+      <%% @<%= user_singular_name %>.errors.full_messages.each do |msg| %>
+        <li><%%= msg %></li>
+      <%% end %>
+      </ul>
+    </div>
+  <%% end %>
   <p>
     <%%= f.label :username %><br />
     <%%= f.text_field :username %>

--- a/rails_generators/nifty_authentication/templates/views/haml/login.html.haml
+++ b/rails_generators/nifty_authentication/templates/views/haml/login.html.haml
@@ -4,7 +4,12 @@
 
 <%- if options[:authlogic] -%>
 = form_for @<%= session_singular_name %> do |f|
-  = f.error_messages
+  - if @<%= session_singular_name %>.errors.any?
+    #error_explanation
+      %h2 = "#{pluralize(@<%= session_singular_name %>.errors.count, "error") } prohibited this <%= session_singular_name %> from being saved:"
+      %ul
+        - @<%= session_singular_name %>.errors.full_messages.each do |msg|
+          %li = msg
   %p
     = f.label :username
     %br

--- a/rails_generators/nifty_authentication/templates/views/haml/signup.html.haml
+++ b/rails_generators/nifty_authentication/templates/views/haml/signup.html.haml
@@ -3,7 +3,12 @@
 %p== Already have an account? #{link_to "Log in", login_path}.
 
 - form_for @<%= user_singular_name %> do |f|
-  = f.error_messages
+  - if @<%= user_singular_name %>.errors.any?
+    #error_explanation
+      %h2 = "#{pluralize(@<%= user_singular_name %>.errors.count, "error") } prohibited this <%= user_singular_name %> from being saved:"
+      %ul
+        - @<%= user_singular_name %>.errors.full_messages.each do |msg|
+          %li = msg
   %p
     = f.label :username
     %br


### PR DESCRIPTION
Update the nifty authentication view templates to explicitly print out validation errors since the error_messages method in ActionView::Helpers::FormBuilder was deprecated in Rails 3

I ran rake but there were a couple of uninitialized constant errors around bcrypt. I couldn't figure out how to circumvent these errors, but given that I only made changes to view templates, I think the errors were unrelated.
