### PR TITLE
view uses '-' instead of '=' in login.html.haml

### DIFF
--- a/lib/generators/nifty/authentication/templates/views/haml/login.html.haml
+++ b/lib/generators/nifty/authentication/templates/views/haml/login.html.haml
@@ -14,7 +14,7 @@
   .actions
     = f.submit "Log in"
 <%- else -%>
-- form_tag <%= session_plural_name %>_path do
+= form_tag <%= session_plural_name %>_path do
   .field
     = label_tag :login, "Username or Email Address"
     = text_field_tag :login, params[:login]


### PR DESCRIPTION
Without this fix, the login form isn't displayed if you aren't using authlogic.

Thanks for the great gem!
